### PR TITLE
Parse performance options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ from am_stl.stl.stl_builder import STLCreator
 # Select an existing STL file
 stl_file = STLfile(r"3dp_model.stl")
 # Load it, which returns a collection of all faces in the STL-file
-face_collection = stl_file.load()
+face_collection = stl_file.load(print_time_info=True, strict_vertex_policy=False, ignore_edges=True)
 
 # Look for faces with overhang
 face_collection.check_for_problems(ignore_grounded=True)

--- a/am_stl/exceptions.py
+++ b/am_stl/exceptions.py
@@ -1,0 +1,2 @@
+class STL_LEAK_EXCEPTION(Exception):
+    pass

--- a/am_stl/geometry/edges.py
+++ b/am_stl/geometry/edges.py
@@ -1,3 +1,7 @@
+from am_stl.exceptions import STL_LEAK_EXCEPTION
+from am_stl.geometry.vertices import Vertex
+
+
 class EdgeCollection(set):
     """
     Collection of Edge objects
@@ -62,4 +66,8 @@ class Edge:
         if face not in self.faces:
             self.faces.append(face)
         else:
-            print("The model is broken beyond repair.")
+            print("BLAH")
+            raise STL_LEAK_EXCEPTION('The model contains leaks, and is broken beyond repair. '
+                                     'Reduced vertex proximity tolerance may in some cases resolve the issue. '
+                                     f'Vertex.proximity_tolerance currently set to: {Vertex.proximity_tolerance}. '
+                                     'If you do not intend to utilize edges: load the STL with ignore_edges=true')

--- a/am_stl/geometry/faces.py
+++ b/am_stl/geometry/faces.py
@@ -1,3 +1,5 @@
+from typing import Tuple, List
+
 import numpy as np
 
 from am_stl.geometry.vertices import VertexCollection
@@ -6,9 +8,9 @@ from timeit import default_timer as timer
 
 
 class FaceCollection:
-    '''
+    """
     Collection of Face objects
-    '''
+    """
 
     def __init__(self, stlfile):
         self.stlfile = stlfile
@@ -23,9 +25,9 @@ class FaceCollection:
         self.total_weight = 0
 
     def append(self, face, ignore_edges=False):
-        '''
+        """
         Add face to face collection
-        '''
+        """
 
         if (isinstance(face, Face) is False):
             raise TypeError('face argument needs to be of type Face()')
@@ -52,15 +54,15 @@ class FaceCollection:
         return
 
     def __iter__(self):
-        '''
+        """
         Contributes to making this class iterable by providing an interface
-        '''
+        """
         return self
 
     def __next__(self):
-        '''
+        """
         Contributes to making this class iterable by providing a pointer.
-        '''
+        """
         if self.iterator_pointer > (len(self.faces) - 1):
             self.iterator_pointer = 0
             raise StopIteration
@@ -69,9 +71,9 @@ class FaceCollection:
             return self.faces[self.iterator_pointer - 1]
 
     def get_warning_count(self):
-        '''
+        """
         Returns the amount of potentially problematic faces
-        '''
+        """
         return len(self.problem_faces)
 
     def get_vertices(self, vtype="all"):
@@ -91,7 +93,17 @@ class FaceCollection:
         return self.vertex_collection
 
     def check_for_problems(self, phi_min=np.pi / 4, ignore_grounded=False, ground_level=0, ground_tolerance=0.01,
-                           angle_tolerance=0.017):
+                           angle_tolerance=0.017) -> Tuple[List, List]:
+        """
+        Sets FaceCollection attributes FaceCollection.problem_faces and FaceCollection.good_faces.
+        These attributes are lists, and are populated with the corresponding faces.
+        :param phi_min: Tolerated angle
+        :param ignore_grounded: Flat overhangs that are grounded are ignored.
+        :param ground_level: Manually set the ground (default is automatic ground detection)
+        :param ground_tolerance: Tolerance for what counts as grounded or not
+        :param angle_tolerance: Tolerance for acceptable overhang angles.
+        :return: List of problem faces, List of good faces.
+        """
         self.total_weight = 0
         self.good_faces = []
         self.problem_faces = []
@@ -105,18 +117,20 @@ class FaceCollection:
             else:
                 self.good_faces.append(f)
 
+        return self.problem_faces, self.good_faces
+
 
 class Face:
-    '''
+    """
     STL polygon face
-    '''
+    """
 
     def __init__(self, face_collection, normal_index, vertex_index):
-        '''
+        """
         vert1, vert2, vert3: vertices of a polygon\n
         n: normal vector\n
         phi_min: minimum angular difference between normal vector and -z_hat before marked as a problematic surface
-        '''
+        """
         self.face_collection = face_collection
         self.normal_index = None
         self.vertex_index = None
@@ -150,9 +164,9 @@ class Face:
         self.edge3.associate_with_face(self)
 
     def __connect_vertices__(self):
-        '''
+        """
         Connect all vertices to each other
-        '''
+        """
         self.vertices[0].set_adjacency(self.vertices[1])
         self.vertices[0].set_adjacency(self.vertices[2])
         self.vertices[1].set_adjacency(self.vertices[2])
@@ -170,7 +184,7 @@ class Face:
 
     def check_for_problems(self, phi_min=np.pi / 4, ignore_grounded=False, ground_level=0, ground_tolerance=0.01,
                            angle_tolerance=0.017, no_weight_update=True):
-        '''
+        """
         phi_min: Min angle before problem, in rads.\n
 
         ignore_grounded: Ignore surfaces close to the floor (prone to visual buggs in python)\n
@@ -181,7 +195,7 @@ class Face:
 
         angle_tolerance: How close to the phi_min an angle needs to be in order to be considered as acceptable.
         Setting this to 0 causes the problem correction process to take much more time.\n
-        '''
+        """
         # Check the angle of the normal factor, and compare it to that of the inverted z-unit vector
         neg_z_hat = [0, 0, -1]
         angle = np.arccos(np.clip(np.dot(self.n_hat, neg_z_hat), -1.0, 1.0))
@@ -265,9 +279,9 @@ class Face:
             return False
 
     def check_grounded(self, ground_level, ground_tolerance):
-        '''
+        """
         Check if this surface is parallel to the ground.
-        '''
+        """
         # Calculate differences between individual vertex Z-elements, and the ground level.
         diff_1 = np.abs(self.vertices[0].get_array()[2] - ground_level)
         diff_2 = np.abs(self.vertices[1].get_array()[2] - ground_level)

--- a/am_stl/geometry/vertices.py
+++ b/am_stl/geometry/vertices.py
@@ -6,10 +6,10 @@ class VertexCollection(set):
     enforce_strict_vertex_policy = True
 
     def add(self, vertex):
-        '''
+        """
         Add vertex to collection.
         O(1), constant time
-        '''
+        """
 
         if VertexCollection.enforce_strict_vertex_policy:
             contains_res = self.contains(vertex)    # Very slow
@@ -90,15 +90,15 @@ class Vertex:
         return h
 
     def get_array(self):
-        '''
+        """
         Returns the vertex as a coordinate vector in the form of a numpy array
-        '''
+        """
         return np.array(self.facecol.stlfile.vertices[self.index])
 
     def set_array(self, array):
-        '''
+        """
         Set the coordinate value of the vertex using a R^3 array
-        '''
+        """
         self.facecol.stlfile.vertices[self.index] = array
 
     def set_adjacency(self, vertex):

--- a/am_stl/geometry/vertices.py
+++ b/am_stl/geometry/vertices.py
@@ -3,14 +3,18 @@ import numpy as np
 
 class VertexCollection(set):
 
+    enforce_strict_vertex_policy = True
+
     def add(self, vertex):
         '''
         Add vertex to collection.
         O(1), constant time
         '''
-        contains_res = self.contains(vertex)
-        if contains_res is not None:
-            return contains_res
+
+        if VertexCollection.enforce_strict_vertex_policy:
+            contains_res = self.contains(vertex)    # Very slow
+            if contains_res is not None:
+                return contains_res
 
         super().add(vertex)
 
@@ -21,6 +25,10 @@ class VertexCollection(set):
         Check if vertex exists in set
         O(n), linear time
         """
+
+        # TODO: Convert vertex collection to a map. The map should map from hash to object
+        # ma = vertex.__repr__() Use repr to assert same memory address
+
         if vertex in self:  # TODO: This is stupid. Fix.
             for v in self:
                 if v.__eq__(vertex):
@@ -31,11 +39,12 @@ class VertexCollection(set):
 
 
 class Vertex:
-    '''
+    """
     Class variables:\n
         eq_method: "exact" or "proximity". Exact is quick, but imprecise. Proximity is slow, but better.\n
-    '''
+    """
     eq_method = "proximity"
+    proximity_tolerance = 0.001
 
     def __init__(self, facecol, index):
         self.facecol = facecol
@@ -61,11 +70,11 @@ class Vertex:
     def __eq__(self, other):
         if Vertex.eq_method == "proximity":
             # Slow, but more certain
-            if abs(self.x() - other.x()) > 0.001:
+            if abs(self.x() - other.x()) > Vertex.proximity_tolerance:
                 return False
-            if abs(self.y() - other.y()) > 0.001:
+            if abs(self.y() - other.y()) > Vertex.proximity_tolerance:
                 return False
-            if abs(self.z() - other.z()) > 0.001:
+            if abs(self.z() - other.z()) > Vertex.proximity_tolerance:
                 return False
             return True
         elif Vertex.eq_method == "exact":

--- a/am_stl/stl/stl_builder.py
+++ b/am_stl/stl/stl_builder.py
@@ -3,9 +3,9 @@ from os.path import exists
 from os import remove
 
 class STLCreator:
-    '''
+    """
     Class for creating STL files out of a FaceCollection
-    '''
+    """
 
     def __init__(self, file_destination, face_collection, overwrite=True):
         # Ensure that all arguments are of the correct type
@@ -24,9 +24,9 @@ class STLCreator:
         self.overwrite = overwrite
 
     def build_file(self):
-        '''
+        """
         Build the STL file
-        '''
+        """
         if self.stream is not None:
             raise IOError("File stream was already opened")
 

--- a/am_stl/stl/stl_builder.py
+++ b/am_stl/stl/stl_builder.py
@@ -1,12 +1,13 @@
 from am_stl.geometry.faces import FaceCollection
-
+from os.path import exists
+from os import remove
 
 class STLCreator:
     '''
     Class for creating STL files out of a FaceCollection
     '''
 
-    def __init__(self, file_destination, face_collection):
+    def __init__(self, file_destination, face_collection, overwrite=True):
         # Ensure that all arguments are of the correct type
         if isinstance(file_destination, str) is False:
             raise TypeError("Filename needs to be a String.")
@@ -14,9 +15,13 @@ class STLCreator:
         if isinstance(face_collection, FaceCollection) is False:
             raise TypeError("Face collection needs to be a FaceCollection.")
 
+        if exists(file_destination) and overwrite is False:
+            raise FileExistsError('File already exists, and overwrite is set to False.')
+
         self.file_destination = file_destination
         self.face_collection = face_collection
         self.stream = None
+        self.overwrite = overwrite
 
     def build_file(self):
         '''
@@ -30,6 +35,9 @@ class STLCreator:
         self.__close_file__()
 
     def __create_file__(self):
+        if exists(self.file_destination) and self.overwrite is True:
+            remove(self.file_destination)
+
         try:
             self.stream = open(file=self.file_destination, mode="x", encoding="utf-8", newline=None)
             self.stream.write("solid GeoAlt\n")

--- a/am_stl/stl/stl_parser.py
+++ b/am_stl/stl/stl_parser.py
@@ -16,10 +16,16 @@ class STLfile:
         self.ground_level = 0
         self.grounded = False  # This variable is set by the external "Face" class.
 
+        self._time_data = {
+            'new_vertex': 0,
+            'new_face': 0,
+            'end_facet': 0
+        }
+
     def rotate(self, theta, axis):
-        '''
+        """
         Rotate the model around the X, Y or Z axis. The results are immediately stored.
-        '''
+        """
         self.grounded = False  # Rotating the model could cause the model to no longer be grounded.
 
         b = np.array(self.vertices).T
@@ -46,58 +52,74 @@ class STLfile:
         self.calculate_ground_level()
 
     def calculate_ground_level(self):
-        '''
+        """
         Fetches the lowest Z-element that can be found in the current orientation of the model.
         Notice that the ground level changes if the model is rotated, but is automatically recalculated and can be fetched through the stl.ground_level variable.
-        '''
+        """
         verts = np.array(self.vertices)
         self.ground_level = verts.min(axis=0)[2]
 
     def __new_face__(self, facecol, n):
-        '''
+        """
         Create and store a new face.
-        '''
+        """
+        t0 = timer()
         normal_index = len(self.normals)
         vertex_index = len(self.vertices)
         self.normals.append(n)
 
         face = Face(facecol, normal_index, vertex_index)
+        self._time_data['new_face'] += timer() - t0
         return face
 
     def __new_vertex__(self, face, array):
-        '''
+        """
         Create and store a new vertex
-        '''
+        """
+        t0 = timer()
         vertex_index = len(self.vertices)
         self.vertices.append(array)
         face.vertices.append(Vertex(face.face_collection, vertex_index))
+        self._time_data['new_vertex'] += timer() - t0
 
-    def load(self) -> FaceCollection:
-        '''
-        This generic load method is used to load any type of .stl-file. It will compensate automatically for ASCII, binary or colored binary STLs.
-        '''
+    def __end_facet__(self, face: Face, facecol: FaceCollection):
+        """
+        Create new face (facet)
+        """
+        t0 = timer()
+        face.n_hat_original = face.refresh_normal_vector()
+        facecol.append(face)
+        self._time_data['end_facet'] += timer() - t0
+
+    def load(self, print_time_info=False) -> FaceCollection:
+        """
+        This generic load method is used to load any type of .stl-file. It will compensate automatically for ASCII,
+        binary or colored binary STLs.
+        """
         f = open(self.filename, 'rb')
         type_str = f.read(5).decode('utf-8')
         f.close()
 
         if "SOLID" in type_str.upper():
             try:
-                return self.load_ascii()
+                return self.load_ascii(print_time_info=print_time_info)
             except UnicodeDecodeError:
                 # If it fails to load as ascii, then it is probaby a binary file.
-                return self.load_binary()
+                return self.load_binary(print_time_info=print_time_info)
         elif "COLOR" in type_str.upper():
             print("COLOR LOAD")
-            return self.load_binary(color=True)
+            return self.load_binary(color=True, print_time_info=print_time_info)
 
-        return self.load_binary()
+        return self.load_binary(print_time_info=print_time_info)
 
-    def load_binary(self, color=False) -> FaceCollection:
-        '''
+    def load_binary(self, color=False, print_time_info=False) -> FaceCollection:
+        """
         Load function specifically made for binary files.
-        '''
+        """
+        t_start = timer()
         facecol = FaceCollection(self)
         f = open(self.filename, 'rb')
+        t_open = timer()
 
         if color is True:
             f.read(80)
@@ -110,6 +132,7 @@ class STLfile:
                 return self.load_binary(color=True)
 
         face_count = int.from_bytes(f.read(4), byteorder='little', signed=False)
+        t_header = timer()
 
         for i in range(0, face_count):
             n = unpack('<fff', f.read(12))
@@ -122,20 +145,30 @@ class STLfile:
             v3 = unpack('<fff', f.read(12))
             self.__new_vertex__(face, [v3[0], v3[1], v3[2]])
 
-            face.n_hat_original = face.refresh_normal_vector()
-            facecol.append(face)
+            self.__end_facet__(face, facecol)
 
             spacer = int.from_bytes(f.read(2), byteorder='little', signed=False)
 
-        f.close()
+        t_unpack = timer()
 
+        f.close()
         self.calculate_ground_level()
+
+        t_end = timer()
+        if print_time_info:
+            print(f'Total time: {t_end-t_start}')
+            print(f'Time file open: {t_open-t_start}')
+            print(f'Time read header: {t_header-t_open}')
+            print(f'Time to unpack: {t_unpack-t_header}')
+            print(f'Time to wrap up: {t_end - t_unpack}')
+
         return facecol
 
-    def load_ascii(self) -> FaceCollection:
-        '''
+    def load_ascii(self, print_time_info=False) -> FaceCollection:
+        """
         Load function specifically made for ASCII files.
-        '''
+        """
+        t_start = timer()
         facecol = FaceCollection(self)
 
         f = open(self.filename, 'r')
@@ -143,6 +176,7 @@ class STLfile:
         fl = 1  # Face line nr
 
         current_face = None
+        t_open = timer()
 
         for line in f:
             if ln == 1:
@@ -170,14 +204,23 @@ class STLfile:
                         [float(search.group(1)), float(search.group(2)), float(search.group(3))]))
                 elif fl == 7:
                     # End facet
-                    current_face.n_hat_original = current_face.refresh_normal_vector()
-                    facecol.append(current_face)
+                    self.__end_facet__(current_face, facecol)
                     current_face = None
                     fl = 0
                 else:
                     raise TypeError("Error encountered when parsing through face. Unhandled face line number.")
                 fl += 1  # Face line += 1
             ln += 1  # File line += 1
+
+        t_unpack = timer()
         f.close()
         self.calculate_ground_level()
+
+        t_end = timer()
+        if print_time_info:
+            print(f'Total time: {t_end-t_start}')
+            print(f'Time file open: {t_open-t_start}')
+            print(f'Time to unpack: {t_unpack-t_open}')
+            print(f'Time to wrap up: {t_end-t_unpack}')
+
         return facecol


### PR DESCRIPTION
Added options to 

1. Ignore edges: If the user does not need the edges, then they can be skipped, reducing load time by about 50%
2. Ignore strict vertex policy: The strict vertex policy asserts that there are no vertex duplicates, which is very important IF you wish to manipulate individual vertices. However, if you do not need to manipulate vertices, then you can safely ignore the duplicates.